### PR TITLE
remove error pop up window upon border error

### DIFF
--- a/carparkgame/car.py
+++ b/carparkgame/car.py
@@ -11,6 +11,8 @@ def try_wrapper(fun):
             fun(*args, **kwargs)
         except AssertionError:
             messagebox.showerror("error", "the car doesnt move in that direction")
+        except game_exceptions.BorderException as e:
+            print(e)
         except game_exceptions.RushHourException as e:
             messagebox.showerror("error", e)
     return dec_fun


### PR DESCRIPTION
add specific border exception clause in move_car decorator that prints to console error details and averts error from general RushHoueException handeling